### PR TITLE
Default templates will be exported with vendor publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Steps to Get Started
 
 4. Publish ```generator.php```
 
-        php artisan vendor:publish --provider="Mitul\Generator\GeneratorServiceProvider"
+        php artisan vendor:publish --provider="Mitul\Generator\GeneratorServiceProvider" --tag=config
 
 5. Fire artisan command to generate API, Scaffold with CRUD views or both API as well as CRUD views.
 
@@ -204,6 +204,15 @@ You need to give a full path of default Controller with your namespace as input.
              
 It will generate AppBaseController again with extending custom namespace controller.
 
+### Customizing generated files
+
+1. Publish templates into ```/resources/api-generator-templates```
+
+        php artisan vendor:publish --provider="Mitul\Generator\GeneratorServiceProvider" --tag=templates
+
+2. Leave only those templates that you want to change. Remove the templates that do not plan to change.
+
+3. Add the remaining files to git and make your magic!
 
 Screenshots
 ------------

--- a/src/Mitul/Generator/CommandData.php
+++ b/src/Mitul/Generator/CommandData.php
@@ -12,7 +12,7 @@ use Config;
 use Illuminate\Support\Str;
 use Mitul\Generator\Commands\APIGeneratorCommand;
 use Mitul\Generator\File\FileHelper;
-use Mitul\Generator\Templates\TemplatesHelper;
+use Mitul\Generator\TemplatesHelper;
 
 class CommandData
 {

--- a/src/Mitul/Generator/Commands/PublishBaseControllerCommand.php
+++ b/src/Mitul/Generator/Commands/PublishBaseControllerCommand.php
@@ -4,7 +4,7 @@ namespace Mitul\Generator\Commands;
 
 use Illuminate\Console\Command;
 use Mitul\Generator\File\FileHelper;
-use Mitul\Generator\Templates\TemplatesHelper;
+use Mitul\Generator\TemplatesHelper;
 use Symfony\Component\Console\Input\InputArgument;
 
 class PublishBaseControllerCommand extends Command

--- a/src/Mitul/Generator/GeneratorServiceProvider.php
+++ b/src/Mitul/Generator/GeneratorServiceProvider.php
@@ -22,10 +22,10 @@ class GeneratorServiceProvider extends ServiceProvider
 		$this->publishes([$configPath => config_path('generator.php')], 'config');
 		$this->publishes([
 			__DIR__ . '/../../../views' => base_path('resources/views'),
-		]);
+		], 'config');
 		$this->publishes([
 			__DIR__ . '/Templates' => base_path('resources/api-generator-templates'),
-		]);
+		], 'templates');
 	}
 
 	/**

--- a/src/Mitul/Generator/GeneratorServiceProvider.php
+++ b/src/Mitul/Generator/GeneratorServiceProvider.php
@@ -23,6 +23,9 @@ class GeneratorServiceProvider extends ServiceProvider
 		$this->publishes([
 			__DIR__ . '/../../../views' => base_path('resources/views'),
 		]);
+		$this->publishes([
+			__DIR__ . '/Templates' => base_path('resources/api-generator-templates'),
+		]);
 	}
 
 	/**

--- a/src/Mitul/Generator/Templates/TemplatesHelper.php
+++ b/src/Mitul/Generator/Templates/TemplatesHelper.php
@@ -12,7 +12,10 @@ class TemplatesHelper
 {
 	public function getTemplate($template, $type = "Common")
 	{
-		$path = base_path('vendor/mitulgolakiya/laravel-api-generator/src/Mitul/Generator/Templates/' . $type . '/' . $template . '.txt');
+		$path = base_path('resources/api-generator-templates/' . $type . '/' . $template . '.txt');
+		if (!file_exists($path)) {
+			$path = base_path('vendor/mitulgolakiya/laravel-api-generator/src/Mitul/Generator/Templates/' . $type . '/' . $template . '.txt');
+		}
 
 		$fileData = file_get_contents($path);
 

--- a/src/Mitul/Generator/TemplatesHelper.php
+++ b/src/Mitul/Generator/TemplatesHelper.php
@@ -5,7 +5,7 @@
  * Time: 4:54 PM
  */
 
-namespace Mitul\Generator\Templates;
+namespace Mitul\Generator;
 
 
 class TemplatesHelper


### PR DESCRIPTION
[Issue 43](https://github.com/mitulgolakiya/laravel-api-generator/issues/43), [44](https://github.com/mitulgolakiya/laravel-api-generator/issues/44)

php artisan vendor:publish --tag=config will publish config and errors.blade view
php artisan vendor:publish --tag=templates will publish all *.txt templates to resources/api-generator-templates
TemplatesHelper will try use template from application before vendor template.
