### PR TITLE
Fix DBAL error: "Unknown database type enum requested"

### DIFF
--- a/src/Mitul/Generator/Utils/TableFieldsGenerator.php
+++ b/src/Mitul/Generator/Utils/TableFieldsGenerator.php
@@ -66,6 +66,7 @@ class TableFieldsGenerator
 
     public function generateFieldsFromTable()
     {
+        $this->schema->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
         $columns = $this->schema->listTableColumns($this->tableName);
 
         $fields = [];


### PR DESCRIPTION
When generating API from a MySQL table that contains enum columns, an error is thrown:

``` bash
"[Doctrine\DBAL\DBALException]
  Unknown database type enum requested, Doctrine\DBAL\Platforms\MySqlPlatform may not support it."
```

This is solved by registering an enum type as a string. See: https://wildlyinaccurate.com/doctrine-2-resolving-unknown-database-type-enum-requested/

You'd still have to do some manual migration tweaking:

``` php
$table->enum('choices', ['foo', 'bar']);
```

...but it doesn't crash. :-)
