### PR TITLE
Remove variable declaration for updateRich

### DIFF
--- a/templates/scaffold/Controller.stub
+++ b/templates/scaffold/Controller.stub
@@ -121,7 +121,7 @@ class $MODEL_NAME$Controller extends AppBaseController
 			return redirect(route('$MODEL_NAME_PLURAL_CAMEL$.index'));
 		}
 
-		$$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->updateRich($request->all(), $id);
+		$this->$MODEL_NAME_CAMEL$Repository->updateRich($request->all(), $id);
 
 		Flash::success('$MODEL_NAME$ updated successfully.');
 


### PR DESCRIPTION
$$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->updateRich($request->all(), $id); should be
just $this->$MODEL_NAME_CAMEL$Repository->updateRich($request->all(), $id);
