### PR TITLE
Thickas patch 1

### DIFF
--- a/src/Mitul/Generator/FormFieldsGenerator.php
+++ b/src/Mitul/Generator/FormFieldsGenerator.php
@@ -91,7 +91,7 @@ class FormFieldsGenerator
 
     public static function radio($templateData, $field)
     {
-        $textField = "";
+        $textField = ''
 
         if (count($field['typeOptions']) > 0) {
             $arr = explode(',', $field['typeOptions']);

--- a/src/Mitul/Generator/FormFieldsGenerator.php
+++ b/src/Mitul/Generator/FormFieldsGenerator.php
@@ -8,6 +8,9 @@ class FormFieldsGenerator
 {
     public static function generateLabel($field)
     {
+        //Field label to field.blade in the custom.
+        return "";
+        
         $label = Str::title(str_replace('_', ' ', $field['fieldName']));
 
         $template = "{!! Form::label('\$FIELD_NAME\$', '\$FIELD_NAME_TITLE\$:') !!}";

--- a/src/Mitul/Generator/FormFieldsGenerator.php
+++ b/src/Mitul/Generator/FormFieldsGenerator.php
@@ -91,7 +91,7 @@ class FormFieldsGenerator
 
     public static function radio($templateData, $field)
     {
-        $textField = ''
+        $textField = '';
 
         if (count($field['typeOptions']) > 0) {
             $arr = explode(',', $field['typeOptions']);

--- a/src/Mitul/Generator/FormFieldsGenerator.php
+++ b/src/Mitul/Generator/FormFieldsGenerator.php
@@ -6,21 +6,6 @@ use Illuminate\Support\Str;
 
 class FormFieldsGenerator
 {
-    public static function generateLabel($field)
-    {
-        //Field label to field.blade in the custom.
-        return "";
-        
-        $label = Str::title(str_replace('_', ' ', $field['fieldName']));
-
-        $template = "{!! Form::label('\$FIELD_NAME\$', '\$FIELD_NAME_TITLE\$:') !!}";
-
-        $template = str_replace('$FIELD_NAME_TITLE$', $label, $template);
-        $template = str_replace('$FIELD_NAME$', $field['fieldName'], $template);
-
-        return $template;
-    }
-
     private static function replaceFieldVars($textField, $field)
     {
         $label = Str::title(str_replace('_', ' ', $field['fieldName']));
@@ -34,9 +19,7 @@ class FormFieldsGenerator
 
     public static function text($templateData, $field)
     {
-        $textField = self::generateLabel($field);
-
-        $textField .= "\n\t{!! Form::text('\$FIELD_NAME\$', null, ['class' => 'form-control']) !!}";
+        $textField = "\n\t{!! Form::text('\$FIELD_NAME\$', null, ['class' => 'form-control']) !!}";
 
         $templateData = str_replace('$FIELD_INPUT$', $textField, $templateData);
 
@@ -47,9 +30,7 @@ class FormFieldsGenerator
 
     public static function textarea($templateData, $field)
     {
-        $textareaField = self::generateLabel($field);
-
-        $textareaField .= "\n\t{!! Form::textarea('\$FIELD_NAME\$', null, ['class' => 'form-control']) !!}";
+        $textareaField = "\n\t{!! Form::textarea('\$FIELD_NAME\$', null, ['class' => 'form-control']) !!}";
 
         $templateData = str_replace('$FIELD_INPUT$', $textareaField, $templateData);
 
@@ -60,9 +41,7 @@ class FormFieldsGenerator
 
     public static function password($templateData, $field)
     {
-        $textField = self::generateLabel($field);
-
-        $textField .= "\n\t{!! Form::password('\$FIELD_NAME\$', ['class' => 'form-control']) !!}";
+        $textField = "\n\t{!! Form::password('\$FIELD_NAME\$', ['class' => 'form-control']) !!}";
 
         $templateData = str_replace('$FIELD_INPUT$', $textField, $templateData);
 
@@ -73,9 +52,7 @@ class FormFieldsGenerator
 
     public static function email($templateData, $field)
     {
-        $textField = self::generateLabel($field);
-
-        $textField .= "\n\t{!! Form::email('\$FIELD_NAME\$', null, ['class' => 'form-control']) !!}";
+        $textField = "\n\t{!! Form::email('\$FIELD_NAME\$', null, ['class' => 'form-control']) !!}";
         $templateData = str_replace('$FIELD_INPUT$', $textField, $templateData);
 
         $templateData = self::replaceFieldVars($templateData, $field);
@@ -85,9 +62,7 @@ class FormFieldsGenerator
 
     public static function file($templateData, $field)
     {
-        $textField = self::generateLabel($field);
-
-        $textField .= "\n\t{!! Form::file('\$FIELD_NAME\$') !!}";
+        $textField = "\n\t{!! Form::file('\$FIELD_NAME\$') !!}";
 
         $templateData = str_replace('$FIELD_INPUT$', $textField, $templateData);
 
@@ -116,7 +91,7 @@ class FormFieldsGenerator
 
     public static function radio($templateData, $field)
     {
-        $textField = self::generateLabel($field);
+        $textField = "";
 
         if (count($field['typeOptions']) > 0) {
             $arr = explode(',', $field['typeOptions']);
@@ -143,9 +118,7 @@ class FormFieldsGenerator
 
     public static function number($templateData, $field)
     {
-        $textField = self::generateLabel($field);
-
-        $textField .= "\n\t{!! Form::number('\$FIELD_NAME\$', null, ['class' => 'form-control']) !!}";
+        $textField = "\n\t{!! Form::number('\$FIELD_NAME\$', null, ['class' => 'form-control']) !!}";
         $templateData = str_replace('$FIELD_INPUT$', $textField, $templateData);
 
         $templateData = self::replaceFieldVars($templateData, $field);
@@ -155,9 +128,7 @@ class FormFieldsGenerator
 
     public static function date($templateData, $field)
     {
-        $textField = self::generateLabel($field);
-
-        $textField .= "\n\t{!! Form::date('\$FIELD_NAME\$', null, ['class' => 'form-control']) !!}";
+        $textField = "\n\t{!! Form::date('\$FIELD_NAME\$', null, ['class' => 'form-control']) !!}";
         $templateData = str_replace('$FIELD_INPUT$', $textField, $templateData);
 
         $templateData = self::replaceFieldVars($templateData, $field);
@@ -167,9 +138,7 @@ class FormFieldsGenerator
 
     public static function select($templateData, $field)
     {
-        $textField = self::generateLabel($field);
-
-        $textField .= "\n\t{!! Form::select('\$FIELD_NAME\$', \$INPUT_ARR\$, null, ['class' => 'form-control']) !!}";
+        $textField = "\n\t{!! Form::select('\$FIELD_NAME\$', \$INPUT_ARR\$, null, ['class' => 'form-control']) !!}";
         $textField = str_replace('$FIELD_NAME$', $field['fieldName'], $textField);
 
         if (count($field['typeOptions']) > 0) {

--- a/templates/routes/scaffold_routes.stub
+++ b/templates/routes/scaffold_routes.stub
@@ -1,6 +1,9 @@
+Route::group(['middleware' => 'web'], function () {
 Route::resource('$MODEL_NAME_PLURAL_CAMEL$', '$MODEL_NAME$Controller');
 
 Route::get('$MODEL_NAME_PLURAL_CAMEL$/{id}/delete', [
     'as' => '$MODEL_NAME_PLURAL_CAMEL$.delete',
     'uses' => '$MODEL_NAME$Controller@destroy',
 ]);
+});
+

--- a/templates/scaffold/views/create.blade.stub
+++ b/templates/scaffold/views/create.blade.stub
@@ -3,7 +3,6 @@
 @section('content')
 <div class="container">
 
-
     {!! Form::open(['route' => '$MODEL_NAME_PLURAL_CAMEL$.store']) !!}
 
         @include('$MODEL_NAME_PLURAL_CAMEL$.fields')

--- a/templates/scaffold/views/create.blade.stub
+++ b/templates/scaffold/views/create.blade.stub
@@ -3,7 +3,7 @@
 @section('content')
 <div class="container">
 
-    {!! Form::open(['route' => '$MODEL_NAME_PLURAL_CAMEL$.store']) !!}
+      {!! Form::open(['route' => '$MODEL_NAME_PLURAL_CAMEL$.store','class'=>'form-horizontal']) !!}
 
         @include('$MODEL_NAME_PLURAL_CAMEL$.fields')
 

--- a/templates/scaffold/views/create.blade.stub
+++ b/templates/scaffold/views/create.blade.stub
@@ -3,7 +3,9 @@
 @section('content')
 <div class="container">
 
+  <!--
     @include('common.errors')
+-->
 
     {!! Form::open(['route' => '$MODEL_NAME_PLURAL_CAMEL$.store']) !!}
 

--- a/templates/scaffold/views/create.blade.stub
+++ b/templates/scaffold/views/create.blade.stub
@@ -3,9 +3,6 @@
 @section('content')
 <div class="container">
 
-  <!--
-    @include('common.errors')
--->
 
     {!! Form::open(['route' => '$MODEL_NAME_PLURAL_CAMEL$.store']) !!}
 

--- a/templates/scaffold/views/create.blade.stub
+++ b/templates/scaffold/views/create.blade.stub
@@ -2,7 +2,11 @@
 
 @section('content')
 <div class="container">
-
+<ol class="breadcrumb">
+  <li><a href="/">HomePage</a></li>
+  <li><a href="{!! route('$MODEL_NAME_PLURAL_CAMEL$.index') !!}">$MODEL_NAME_PLURAL$</a></li>
+  <li class="active">Create</li>
+</ol>
       {!! Form::open(['route' => '$MODEL_NAME_PLURAL_CAMEL$.store','class'=>'form-horizontal']) !!}
 
         @include('$MODEL_NAME_PLURAL_CAMEL$.fields')

--- a/templates/scaffold/views/edit.blade.stub
+++ b/templates/scaffold/views/edit.blade.stub
@@ -4,7 +4,7 @@
 <div class="container">
 
 
-    {!! Form::model($$MODEL_NAME_CAMEL$, ['route' => ['$MODEL_NAME_PLURAL_CAMEL$.update', $$MODEL_NAME_CAMEL$->id], 'method' => 'patch']) !!}
+    {!! Form::model($$MODEL_NAME_CAMEL$, ['route' => ['$MODEL_NAME_PLURAL_CAMEL$.update', $$MODEL_NAME_CAMEL$->id], 'method' => 'patch','class'=>'form-horizontal']) !!}
 
         @include('$MODEL_NAME_PLURAL_CAMEL$.fields')
 

--- a/templates/scaffold/views/edit.blade.stub
+++ b/templates/scaffold/views/edit.blade.stub
@@ -3,7 +3,6 @@
 @section('content')
 <div class="container">
 
-    @include('common.errors')
 
     {!! Form::model($$MODEL_NAME_CAMEL$, ['route' => ['$MODEL_NAME_PLURAL_CAMEL$.update', $$MODEL_NAME_CAMEL$->id], 'method' => 'patch']) !!}
 

--- a/templates/scaffold/views/edit.blade.stub
+++ b/templates/scaffold/views/edit.blade.stub
@@ -2,7 +2,11 @@
 
 @section('content')
 <div class="container">
-
+<ol class="breadcrumb">
+  <li><a href="/">HomePage</a></li>
+  <li><a href="{!! route('$MODEL_NAME_PLURAL_CAMEL$.index') !!}">$MODEL_NAME_PLURAL$</a></li>
+  <li class="active">Edit</li>
+</ol>
 
     {!! Form::model($$MODEL_NAME_CAMEL$, ['route' => ['$MODEL_NAME_PLURAL_CAMEL$.update', $$MODEL_NAME_CAMEL$->id], 'method' => 'patch','class'=>'form-horizontal']) !!}
 

--- a/templates/scaffold/views/field.blade.stub
+++ b/templates/scaffold/views/field.blade.stub
@@ -1,4 +1,12 @@
 <!-- $FIELD_NAME_TITLE$ Field -->
-<div class="form-group col-sm-6 col-lg-4">
-    $FIELD_INPUT$
+<div class="form-group{{ $errors->has('$FIELD_NAME$') ? ' has-error' : '' }}">
+    {!! Form::label('$FIELD_NAME$', '$FIELD_NAME_TITLE$:',['class'=>'col-md-3 control-label']) !!}
+    <div class="col-md-6">
+        $FIELD_INPUT$
+        @if ($errors->has('$FIELD_NAME$'))
+            <span class="help-block">
+                <strong>{{ $errors->first('$FIELD_NAME$') }}</strong>
+            </span>
+        @endif
+    </div>
 </div>

--- a/templates/scaffold/views/fields.blade.stub
+++ b/templates/scaffold/views/fields.blade.stub
@@ -1,5 +1,7 @@
 $FIELDS$
 <!-- Submit Field -->
-<div class="form-group col-sm-12">
+<div class="form-group">
+  <div class="col-md-6 col-md-offset-3">
     {!! Form::submit('Save', ['class' => 'btn btn-primary']) !!}
+    </div>
 </div>

--- a/templates/scaffold/views/index.blade.stub
+++ b/templates/scaffold/views/index.blade.stub
@@ -4,6 +4,12 @@
 
     <div class="container">
 
+<ol class="breadcrumb">
+  <li><a href="/">HomePage</a></li>
+  <li><a href="{!! route('$MODEL_NAME_PLURAL_CAMEL$.index') !!}">$MODEL_NAME_PLURAL$</a></li>
+  <li class="active">List</li>
+</ol>
+
         @include('flash::message')
 
         <div class="row">

--- a/templates/scaffold/views/show.blade.stub
+++ b/templates/scaffold/views/show.blade.stub
@@ -2,6 +2,12 @@
 
 @section('content')
 <div class="container">
+<ol class="breadcrumb">
+  <li><a href="/">HomePage</a></li>
+  <li><a href="{!! route('$MODEL_NAME_PLURAL_CAMEL$.index') !!}">$MODEL_NAME_PLURAL$</a></li>
+  <li class="active">Profile</li>
+</ol>
+
 	 @include('$MODEL_NAME_PLURAL_CAMEL$.show_fields')
 </div>
 @endsection


### PR DESCRIPTION
1. Field label to field.blade in the custom.
2. Delete and Edit page Create common error display code, and will check the error message, display to the specific Input control below (see field.blade.stub), and the form to the horizontal layout.
3. Add breadcrumb bar.
4. Fixes the problem that the form cannot be displayed to verify the error message, because the routing middleware is not set(ShareErrorsFromSession no effect).
